### PR TITLE
Support dedicated QueueBus Redis instance

### DIFF
--- a/lib/resque_bus/adapter.rb
+++ b/lib/resque_bus/adapter.rb
@@ -1,6 +1,7 @@
 module QueueBus
   module Adapters
     class Resque < QueueBus::Adapters::Base
+
       def enabled!
         # know we are using it
         require 'resque'
@@ -11,16 +12,59 @@ module QueueBus
         QueueBus::Worker.extend(::QueueBus::Adapters::Resque::RetryHandlers)
       end
 
-      def redis(&block)
+      def redis=(server)
+        @queuebus_redis = nil
+        @queuebus_redis_url = server
+      end
+
+      # This method returns the QueueBus Redis instance
+      # If it is not configured, it will default to the same instance as Resque.
+      # If it is configured, it will me intialized, memoized, and returned.
+      def queuebus_redis
+        @queuebus_redis ||
+          if @queuebus_redis_url
+            # The configuration has specified a custom server just for QueueBus.
+            # Resque doesn't offer a mechanism to create a Redis object without
+            # assignment, though, so we invoke assignment for its side-effects.
+
+            # Save the default Resque redis connection
+            default_redis = ::Resque.redis
+            # Get Resque to generate the connection given the server definition
+            ::Resque.redis = @queuebus_redis_url
+            # Store the Redis namespace that Resque created...
+            @queuebus_redis = ::Resque.redis
+            # ...and restore the default.
+            ::Resque.redis = default_redis
+            @queuebus_redis
+          else
+            ::Resque.redis
+          end
+      end
+
+      def with_queuebus_redis(&block)
+        default_redis = ::Resque.redis
+        ::Resque.redis = queuebus_redis
         block.call(::Resque.redis)
+      ensure
+        ::Resque.redis = default_redis
+      end
+
+      def redis(&block)
+        with_queuebus_redis do
+          block.call(::Resque.redis)
+        end
       end
 
       def enqueue(queue_name, klass, json)
-        ::Resque.enqueue_to(queue_name, klass, json)
+        with_queuebus_redis do
+          ::Resque.enqueue_to(queue_name, klass, json)
+        end
       end
 
       def enqueue_at(epoch_seconds, queue_name, klass, json)
-        ::Resque.enqueue_at_with_queue(queue_name, epoch_seconds, klass, json)
+        with_queuebus_redis do
+          ::Resque.enqueue_at_with_queue(queue_name, epoch_seconds, klass, json)
+        end
       end
 
       def setup_heartbeat!(queue_name)

--- a/lib/resque_bus/adapter.rb
+++ b/lib/resque_bus/adapter.rb
@@ -39,8 +39,6 @@ module QueueBus
         ::Resque.schedule[name] = schedule
       end
 
-      private
-
       module RetryHandlers
         # @failure_hooks_already_ran on https://github.com/defunkt/resque/tree/1-x-stable
         # to prevent running twice
@@ -52,7 +50,7 @@ module QueueBus
           # note: sorted alphabetically
           # queue needs to be set for rety to work (know what queue in Requeue.class_to_queue)
           hash = ::QueueBus::Util.decode(args[0])
-          @my_queue = hash["bus_rider_queue"]
+          @my_queue = hash['bus_rider_queue']
         end
 
         def on_failure_zzz(exception, *args)

--- a/lib/resque_bus/server.rb
+++ b/lib/resque_bus/server.rb
@@ -10,16 +10,15 @@ module ResqueBus
     def self.included(base)
       base.class_eval {
 
-        get "/bus" do
-          erb File.read(File.join(File.dirname(__FILE__), "server/views/bus.erb"))
+        get '/bus' do
+          erb File.read(File.join(File.dirname(__FILE__), 'server/views/bus.erb'))
         end
-        
-        
+
         post '/bus/unsubscribe' do
-          app = Application.new(params[:name]).unsubscribe
+          Application.new(params[:name]).unsubscribe
           redirect u('bus')
         end
-        
+
       }
     end
   end

--- a/spec/adapter/support.rb
+++ b/spec/adapter/support.rb
@@ -20,4 +20,3 @@ def perform_next_job(worker, &block)
   worker.perform(job, &block)
   worker.done_working
 end
-

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -1,14 +1,15 @@
 require 'spec_helper'
 
-describe "adapter is set" do
-  it "should call it's enabled! method on init" do
+describe 'adapter is set' do
+
+  it 'should call the enabled! method on init' do
     QueueBus.send(:reset)
     adapter_under_test_class.any_instance.should_receive(:enabled!)
-    instance = adapter_under_test_class.new
+    adapter_under_test_class.new
     QueueBus.send(:reset)
   end
 
-  it "should be defaulting to Data from spec_helper" do
-    QueueBus.adapter.is_a?(adapter_under_test_class).should == true
+  it 'defaults to Data from spec_helper' do
+    QueueBus.adapter.is_a?(adapter_under_test_class).should eq(true)
   end
 end

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -12,4 +12,44 @@ describe 'adapter is set' do
   it 'defaults to Data from spec_helper' do
     QueueBus.adapter.is_a?(adapter_under_test_class).should eq(true)
   end
+
+  context 'with no custom QueueBus Redis configuration' do
+
+    let(:resque_url) { 'redis://localhost:6379/0' }
+    let(:active_url) { ::Resque.redis.redis.client.options[:url] }
+
+    before(:each) do
+      Resque.redis = resque_url
+    end
+
+    it 'uses the default redis instance' do
+      QueueBus.adapter.redis do
+        active_url.should eq(resque_url)
+      end
+    end
+
+  end
+
+  context 'with a custom QueueBus Redis configuration' do
+    let(:resque_url) { 'redis://localhost:6379/0' }
+    let(:queuebus_url) { 'redis://localhost:6379/1' }
+    let(:active_url) { ::Resque.redis.redis.client.options[:url] }
+
+    before(:each) do
+      Resque.redis = resque_url
+      QueueBus.adapter.redis = queuebus_url
+    end
+
+    it 'still uses the default for Resque jobs' do
+      active_url.should eq(resque_url)
+    end
+
+    it 'uses the custom Redis instance for QueueBus jobs' do
+      QueueBus.adapter.redis do
+        active_url.should eq(queuebus_url)
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
Clients can specify a dedicate instance using:

``` ruby
QueueBus.adapter.redis = some_redis_server_description
```

The accepted formats are identical to those accepted by Resque.  The Redis connection, once established, will be memoized to avoid connection thrash.

I think this resolves issue #2, though I'm not sure I implemented as suggested.

@ryanscott @sashah87 
