### PR TITLE
Add :use_queuebus_redis to setup task

### DIFF
--- a/lib/resque_bus/tasks.rb
+++ b/lib/resque_bus/tasks.rb
@@ -41,7 +41,7 @@ namespace :queuebus do
   Rake::Task[:unsubscribe].enhance [:use_queuebus_redis]
 
   desc 'Setup will configure a resque task to run before resque:work'
-  task setup: [:preload, :set_redis_server] do
+  task setup: [:preload, :use_queuebus_redis, :set_redis_server] do
 
     if ENV['QUEUES'].nil?
       manager = ::QueueBus::TaskManager.new(true)

--- a/lib/resque_bus/tasks.rb
+++ b/lib/resque_bus/tasks.rb
@@ -33,6 +33,7 @@ namespace :queuebus do
   task :set_redis_server do
     unless ENV['USE_QUEUEBUS_REDIS'].nil?
       Resque.redis = QueueBus.adapter.queuebus_redis
+      puts "set Resque.redis = #{Resque.redis}"
     end
   end
 
@@ -62,6 +63,7 @@ namespace :queuebus do
   task :use_queuebus_redis do
     # We pass state through the environment because the actual worker runs
     # in a different process
+    puts "set ENV[USE_QUEUEBUS_REDIS] = true"
     ENV['USE_QUEUEBUS_REDIS'] = 'true'
   end
 

--- a/lib/resque_bus/tasks.rb
+++ b/lib/resque_bus/tasks.rb
@@ -33,7 +33,6 @@ namespace :queuebus do
   task :set_redis_server do
     unless ENV['USE_QUEUEBUS_REDIS'].nil?
       Resque.redis = QueueBus.adapter.queuebus_redis
-      puts "set Resque.redis = #{Resque.redis}"
     end
   end
 
@@ -63,7 +62,6 @@ namespace :queuebus do
   task :use_queuebus_redis do
     # We pass state through the environment because the actual worker runs
     # in a different process
-    puts "set ENV[USE_QUEUEBUS_REDIS] = true"
     ENV['USE_QUEUEBUS_REDIS'] = 'true'
   end
 


### PR DESCRIPTION
Add `:use_queuebus_redis` to setup task, so that `:set_redis_server` actually sets the `Resque.redis` value

@rpdillon 
